### PR TITLE
adjusting paths to account for any symlinks involved

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -593,8 +593,8 @@ HostConfig() {
 
     # Where is the software
     PLEX_SQLITE="/Applications/Plex Media Server.app/Contents/MacOS/Plex SQLite"
-    AppSuppDir="$HOME/Library/Application Support"
-    DBDIR="$AppSuppDir/Plex Media Server/Plug-in Support/Databases"
+    AppSuppDir="$HOME/Library/Application Support/Plex Media Server"
+    DBDIR="$AppSuppDir/Plug-in Support/Databases"
     CACHEDIR="$HOME/Library/Caches/PlexMediaServer/PhotoTranscoder"
     LOGFILE="$DBDIR/DBRepair.log"
     LOG_TOOL="logger"


### PR DESCRIPTION
Howdy!

Recently ran into an issue where DBRepair was throwing an insufficient space error. After digging it its because it was checking the space of the Application Support directory. I have my Application Support/Plex Media Server directory symlinked to another drive on a locally attached disk with over 2TB of space free. The free disk space check was not correctly checking where the actual directory was stored.

This should fix it without breaking anything from what I can tell, and fixed my issue as well.