### PR TITLE
Provide temporary DB bloat deflate capability for huge databases

### DIFF
--- a/ReleaseNotes
+++ b/ReleaseNotes
@@ -8,6 +8,26 @@
 ![Maintenance](https://img.shields.io/badge/Maintained-Yes-green.svg)
 
 # Release Info:
+v1.11.02                  - Special release
+
+  1. Database bloat       - (Enh) A better method was found to handle bloat processing.
+                            This new method works on SSD/HDDs where the disk is full and PMS can't run.
+                            There is no free space required to perform this task.
+
+                            Each "block" being removed is 100 million records.
+                            The CPU will have one core maxed at 100% for the duration.
+
+                            Before & after info will be printed after final cleanup is finished.
+
+                            New command name:  Deflate  ( # 911 )
+
+v1.11.01
+
+  1. Database bloat       - (New) Database bloat processing now surrounded by TRANSACTION/COMMIT to speed processing.
+  2. Space Needed         - (Fix) Handle cases where "Databases" directory is not on the same volume as AppSuppDir.
+  3. Menu options         - (New) Add option 98 = quit. Rename 99 = exit.
+  4. Reporting            - (Fix) When insufficient space available, Now print out how much is needed
+
 v1.11.00
 
   1. Rename Utility       - Rename this tool to be compliant with Plex inc. Trademark Policy.


### PR DESCRIPTION
Many folks have experienced the PMS 1.41.7 database bloat problem.
Some are so severe  PMS cannot start (no free disk space)

This release adds a means by which the known-bad records can be removed from the Plex database without risking data corruption  

A special command 'DEFLATE' was added (numeric code '911') for this.
It does not require all the free space a normal optimization does
It is written to withstand being interrupted (not desired)  and will run until
all known-bad records are removed.

Processing time for this release is much faster than the 1.11.01
Interim progress is printed

Before & After size info is printed upon completion.
