### PR TITLE
Add 98=quit/99=exit to PowerShell script

### DIFF
--- a/Windows/DBRepair-Windows.bat
+++ b/Windows/DBRepair-Windows.bat
@@ -12,7 +12,7 @@ setlocal enabledelayedexpansion
 
 echo.
 echo NOTE: This script is being replaced with the PowerShell script DBRepair-Windows.ps1,
-echo       which aims to better emulate DBRepair.sh (more options, interative mode, etc).
+echo       which aims to better emulate DBRepair.sh (more options, interactive mode, etc).
 echo       Consider moving over to the new script.
 echo.
 
@@ -135,8 +135,8 @@ del "%TmpFile%"
 echo %time% --  Main DB verification check is: %Result%
 echo %time% --  Main DB verification check is: %Result% >> "%PlexData%\DBRepair.log"
 if not "%Result%" == "ok" (
-  echo %time% --  ERROR: Main DB verificaion failed. Exiting.
-  echo %time% --  ERROR: Main DB verificaion failed. Exiting. >> "%PlexData%\DBRepair.log"
+  echo %time% --  ERROR: Main DB verification failed. Exiting.
+  echo %time% --  ERROR: Main DB verification failed. Exiting. >> "%PlexData%\DBRepair.log"
   exit /B 4
 )
 echo %time% --  Main DB verification successful.
@@ -161,8 +161,8 @@ del "%TmpFile%"
 echo %time% --  Blobs DB verification check is: %Result%
 echo %time% --  Blobs DB verification check is: %Result% >> "%PlexData%\DBRepair.log"
 if not "%Result%" == "ok" (
-  echo %time% -- ERROR: Blobs DB verificaion failed. Exiting.
-  echo %time% -- ERROR: Blobs DB verificaion failed. Exiting. >> "%PlexData%\DBRepair.log"
+  echo %time% -- ERROR: Blobs DB verification failed. Exiting.
+  echo %time% -- ERROR: Blobs DB verification failed. Exiting. >> "%PlexData%\DBRepair.log"
   exit /B 6
 )
 echo %time% --  Blobs DB verification successful.

--- a/Windows/ReleaseNotes-Windows
+++ b/Windows/ReleaseNotes-Windows
@@ -4,6 +4,11 @@ Release notes for the Windows counterpart to DBRepair.sh (DBRepair-Windows.ps1)
 
 # Release Info
 
+v1.01.02
+  - Remove `statistics_bandwidth` pruning, as it's now part of PMS 1.41.8
+  - Change `quit` to 98 and `exit` to 99
+  - Minor logging refactoring
+
 v1.01.01
   - Add `staticstics_bandwidth` pruning during automatic repair.
 


### PR DESCRIPTION
Copy DBRepair.sh's method of deflating a bloated PMS database.

Also copies DBRepair.sh's recent change mapping 98 to `quit` and 99 to `exit`.

Fixes #209 