### PR TITLE
chore: removed left over 'deflate' option from DBRepair.sh menu

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -1964,8 +1964,6 @@ do
       echo " 88 - 'update'    - Check for updates."
       echo " 98 - 'quit'      - Quit immediately.  Keep all temporary files."
       echo " 99 - 'exit'      - Exit with cleanup options."
-      echo " "
-      echo "911 - 'deflate'   - Deflate a bloated PMS database"
     fi
 
     if [ $Scripted -eq 0 ]; then

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -2411,4 +2411,3 @@ do
     esac
   done
 done
-exit 0

--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -2411,3 +2411,5 @@ do
     esac
   done
 done
+
+exit 0


### PR DESCRIPTION
hey @ChuckPa 

yesterday I saw that you removed the deflate option from v1.11.04 - but I saw it still in the menu. I don't if that way by accident that it still sits there. If so this removes it - if it was by intent feel free to abandon this PR.

thanks for your great work 👋🏼 
m.