### PR TITLE
FreeBSD 14+ Compatibility Added.

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -7,7 +7,7 @@
 #########################################################################
 
 # Version for display purposes
-Version="v1.11.06"
+Version="v1.11.07"
 
 # Have the databases passed integrity checks
 CheckedDB=0
@@ -377,7 +377,7 @@ GetOverride() {
 # Determine which host we are running on and set variables
 HostConfig() {
 
-  # On all hosts except Mac
+  # On all hosts except Mac/FreeBSD
   PIDOF="pidof"
   STATFMT="-c"
   STATBYTES="%s"
@@ -624,6 +624,66 @@ HostConfig() {
     HapticOkay=1
 
     HostType="Mac"
+    return 0
+
+ # FreeBSD 14+
+  elif [ -e /etc/os-release ] && [ "$(cat /etc/os-release | grep FreeBSD)" != "" ]; then
+
+    # Load functions for interacting with FreeBSD RC System
+    . /etc/rc.subr
+
+    # Find PMS
+    PLEXPKG=$(pkg info | grep plexmediaserver | awk '{print $1}')
+
+    if [ "x$PLEXPKG" != "x" ]; then # Plex ports package is installed
+      BsdRcFile=$(pkg list $PLEXPKG | grep "/usr/local/etc/rc.d")
+      BsdService=$(basename $BsdRcFile)
+      # FreeBSD Ports has two packages for Plex - determine which one is installed
+      BsdPlexPass="$(pkg info $PLEXPKG | grep ^Name | awk '{print $3}' | sed -e 's/plexmediaserver//')"
+
+      # Load FreeBSD RC configuration for Plex
+      load_rc_config $BsdService
+
+      # Use FreeBSD RC configuration to set paths
+      if [ "x$plexmediaserver_plexpass_support_path" != "x" ]; then
+        DBDIR="${plexmediaserver_plexpass_support_path}/Plex Media Server/Plug-in Support/Databases"
+        CACHEDIR="${plexmediaserver_plexpass_support_path}/Cache"
+      elif [ "x$plexmediaserver_support_path" != "x" ]; then
+        DBDIR="${plexmediaserver_support_path}/Plex Media Server/Plug-in Support/Databases"
+        CACHEDIR="${plexmediaserver_support_path}/Cache"
+      else
+        # System is using default Ports package configuration paths
+        DBDIR="/usr/local/plexdata${BsdPlexPass}/Plex Media Server/Plug-in Support/Databases"
+        CACHEDIR="/usr/local/plexdata${BsdPlexPass}/Cache"
+      fi
+
+      # Where is the software
+      AppSuppDir=$(dirname `pkg list $PLEXPKG | grep Plex_Media_Server`)
+      PLEX_SQLITE="${AppSuppDir}/Plex SQLite"
+      LOGFILE="$DBDIR/DBRepair.log"
+      LOG_TOOL="logger"
+      TMPDIR="/tmp"
+      SYSTMP="$TMPDIR"
+    else
+      Output "Plex Media Server FreeBSD PKG is not installed!"
+      Fail=1
+      return 1
+    fi
+
+    # FreeBSD uses pgrep and uses different stat options
+    PIDOF="pgrep"
+    STATFMT="-f"
+    STATBYTES="%z"
+    STATPERMS="%Lp"
+
+    # User 'plex' exists on FreeBSD, but the tool may not be run as that service account.
+    RootRequired=1
+
+    HaveStartStop=1
+    StartCommand="/usr/sbin/service plexmediaserver${BsdService} start"
+    StopCommand="/usr/sbin/service plexmediaserver${BsdService} stop"
+
+    HostType="FreeBSD"
     return 0
 
   # Western Digital (OS5)
@@ -1834,7 +1894,7 @@ Scripted=0
 
 # Identify this host
 if [ $ManualConfig -eq 0 ] && ! HostConfig; then
-  Output 'Error: Unknown host. Current supported hosts are: QNAP, Syno, Netgear, Mac, ASUSTOR, WD (OS5), Linux wkstn/svr, SNAP'
+  Output 'Error: Unknown host. Current supported hosts are: QNAP, Syno, Netgear, Mac, ASUSTOR, WD (OS5), Linux wkstn/svr, SNAP, FreeBSD 14+'
   Output '                     Current supported container images:  Plexinc, LinuxServer, HotIO, & BINHEX'
   Output '                     Manual host configuration is available in most use cases.'
   Output ' '


### PR DESCRIPTION
See closed PR "Freebsd compat #224" for discussion.
Updated version.
Uses FreeBSD Ports (pkg command) to determine which plexmediaserver package is installed and sets paths.
Sets 'stat' options for FreeBSD.