### PR TITLE
Fixed bug for FreeBSD Plex service start/stop commands

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -680,8 +680,8 @@ HostConfig() {
     RootRequired=1
 
     HaveStartStop=1
-    StartCommand="/usr/sbin/service plexmediaserver${BsdService} start"
-    StopCommand="/usr/sbin/service plexmediaserver${BsdService} stop"
+    StartCommand="/usr/sbin/service ${BsdService} start"
+    StopCommand="/usr/sbin/service ${BsdService} stop"
 
     HostType="FreeBSD"
     return 0


### PR DESCRIPTION
Fixed bug where the FreeBSD Plex service start/stop command was not formed correctly.