### PR TITLE
Fixed bug in FreeBSD cache prune operation

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -647,14 +647,14 @@ HostConfig() {
       # Use FreeBSD RC configuration to set paths
       if [ "x$plexmediaserver_plexpass_support_path" != "x" ]; then
         DBDIR="${plexmediaserver_plexpass_support_path}/Plex Media Server/Plug-in Support/Databases"
-        CACHEDIR="${plexmediaserver_plexpass_support_path}/Cache"
+        CACHEDIR="${plexmediaserver_plexpass_support_path}/Plex Media Server/Cache"
       elif [ "x$plexmediaserver_support_path" != "x" ]; then
         DBDIR="${plexmediaserver_support_path}/Plex Media Server/Plug-in Support/Databases"
-        CACHEDIR="${plexmediaserver_support_path}/Cache"
+        CACHEDIR="${plexmediaserver_support_path}/Plex Media Server/Cache"
       else
         # System is using default Ports package configuration paths
         DBDIR="/usr/local/plexdata${BsdPlexPass}/Plex Media Server/Plug-in Support/Databases"
-        CACHEDIR="/usr/local/plexdata${BsdPlexPass}/Cache"
+        CACHEDIR="/usr/local/plexdata${BsdPlexPass}/Plex Media Server/Cache"
       fi
 
       # Where is the software


### PR DESCRIPTION
The path for the CACHEDIR variable was incorrect for pruning operations.

This has been corrected and tested.

```
Select

  1 - 'stop'      - Stop PMS.
  2 - 'automatic' - Check, Repair/Optimize, and Reindex Database in one step.
  3 - 'check'     - Perform integrity check of database.
  4 - 'vacuum'    - Remove empty space from database without optimizing.
  5 - 'repair'    - Repair/Optimize databases.
  6 - 'reindex'   - Rebuild database indexes.
  7 - 'start'     - Start PMS

  8 - 'import'    - Import watch history from another database independent of Plex. (risky).
  9 - 'replace'   - Replace current databases with newest usable backup copy (interactive).
 10 - 'show'      - Show logfile.
 11 - 'status'    - Report status of PMS (run-state and databases).
 12 - 'undo'      - Undo last successful command.

 21 - 'prune'     - Remove old image files (jpeg,jpg,png) from PhotoTranscoder cache & all temp files left by PMS.
 42 - 'ignore'    - Ignore duplicate/constraint errors.

 88 - 'update'    - Check for updates.
 98 - 'quit'      - Quit immediately.  Keep all temporary files.
 99 - 'exit'      - Exit with cleanup options.

Enter command # -or- command name (4 char min) : 21
 
Counting how many files can be removed.
OK to prune 1712 files?  (Y/N) ? n
```