### PR TITLE
Verify FTS rebuild with CheckFTS instead of trusting the rebuild exit code

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -2599,12 +2599,12 @@ do
           Output "FTS indexes are damaged. Attempting automatic FTS rebuild..."
           WriteLog "Auto    - FTS damaged, attempting rebuild"
 
-          if DoFTSRebuild; then
-            WriteLog "Auto    - FTS Rebuild - PASS"
-            Output "FTS rebuild successful."
+          if DoFTSRebuild && CheckFTS "Auto   "; then
+            WriteLog "Auto    - FTS Rebuild - PASS (verified)"
+            Output "FTS rebuild successful and verified clean."
           else
-            WriteLog "Auto    - FTS Rebuild - FAIL"
-            Output "FTS rebuild failed. You may need to run 'reindex' command manually."
+            WriteLog "Auto    - FTS Rebuild - FAIL (unverified or still damaged)"
+            Output "FTS rebuild did not produce a verified-clean index. You may need to run 'reindex' command manually."
             # Don't fail auto entirely - main DB repair succeeded
           fi
         else
@@ -2714,12 +2714,12 @@ do
               Output "FTS indexes are damaged. Rebuilding..."
               WriteLog "Reindex - FTS damaged, attempting rebuild"
 
-              if DoFTSRebuild; then
-                WriteLog "Reindex - FTS Rebuild - PASS"
-                Output "FTS rebuild successful."
+              if DoFTSRebuild && CheckFTS "Reindex"; then
+                WriteLog "Reindex - FTS Rebuild - PASS (verified)"
+                Output "FTS rebuild successful and verified clean."
               else
-                WriteLog "Reindex - FTS Rebuild - FAIL"
-                Output "FTS rebuild failed."
+                WriteLog "Reindex - FTS Rebuild - FAIL (unverified or still damaged)"
+                Output "FTS rebuild did not produce a verified-clean index."
               fi
             else
               WriteLog "Reindex - FTS Check - PASS"


### PR DESCRIPTION
Fixes #289.

## What
`automatic` and `reindex` both report `FTS Rebuild - PASS` / "FTS rebuild successful" based only on whether the `'rebuild'` SQL statement itself threw an error — they never re-ran `CheckFTS` (the same function that detected the damage) to confirm the index is actually clean afterward.

This adds a second `CheckFTS` call after `DoFTSRebuild` in both call sites and gates the PASS/FAIL message on it, instead of just the rebuild statement's exit code.

## Testing
- `bash -n` passes.
- `shellcheck` output is byte-identical before/after the patch (no new warnings introduced).
- Tested live against a real database with confirmed, reproducible FTS corruption (the one behind #289): copied the patched script into the running Plex container and ran `stop automatic start exit` against it. The new verification step visibly re-ran `CheckFTS` after the rebuild, found all tables clean, and only then reported "FTS rebuild successful and verified clean." Cross-checked independently outside the script and confirmed the DB really was clean at that point.

One thing worth flagging honestly: in that same environment, the database re-corrupted again roughly 19 seconds after this verified-clean result — a separate, underlying issue (see the discussion on #289) that this PR doesn't attempt to fix. This PR only makes the tool's own success/failure reporting truthful; it doesn't and can't guarantee the fix holds, since that depends on whatever is causing the recurrence in the first place.
