### PR TITLE
Verify FTS rebuild with CheckFTS instead of trusting the rebuild exit code

### DIFF
--- a/DBRepair.sh
+++ b/DBRepair.sh
@@ -2599,12 +2599,12 @@ do
           Output "FTS indexes are damaged. Attempting automatic FTS rebuild..."
           WriteLog "Auto    - FTS damaged, attempting rebuild"
 
-          if DoFTSRebuild; then
-            WriteLog "Auto    - FTS Rebuild - PASS"
-            Output "FTS rebuild successful."
+          if DoFTSRebuild && CheckFTS "Auto   "; then
+            WriteLog "Auto    - FTS Rebuild - PASS (verified)"
+            Output "FTS rebuild successful and verified clean."
           else
-            WriteLog "Auto    - FTS Rebuild - FAIL"
-            Output "FTS rebuild failed. You may need to run 'reindex' command manually."
+            WriteLog "Auto    - FTS Rebuild - FAIL (unverified or still damaged)"
+            Output "FTS rebuild did not produce a verified-clean index. You may need to run 'reindex' command manually."
             # Don't fail auto entirely - main DB repair succeeded
           fi
         else
@@ -2714,12 +2714,12 @@ do
               Output "FTS indexes are damaged. Rebuilding..."
               WriteLog "Reindex - FTS damaged, attempting rebuild"
 
-              if DoFTSRebuild; then
-                WriteLog "Reindex - FTS Rebuild - PASS"
-                Output "FTS rebuild successful."
+              if DoFTSRebuild && CheckFTS "Reindex"; then
+                WriteLog "Reindex - FTS Rebuild - PASS (verified)"
+                Output "FTS rebuild successful and verified clean."
               else
-                WriteLog "Reindex - FTS Rebuild - FAIL"
-                Output "FTS rebuild failed."
+                WriteLog "Reindex - FTS Rebuild - FAIL (unverified or still damaged)"
+                Output "FTS rebuild did not produce a verified-clean index."
               fi
             else
               WriteLog "Reindex - FTS Check - PASS"


### PR DESCRIPTION
Automatic and Reindex both reported FTS Rebuild PASS / "successful" based
solely on whether the rebuild SQL statement itself errored, never re-running
CheckFTS (the same function used to detect the damage) to confirm the index
is actually clean afterward.

Call CheckFTS again after DoFTSRebuild in both paths and gate the PASS/FAIL
message on its result. Tested live against a database with confirmed FTS
corruption (see issue #289): the new verification step now visibly re-checks
after rebuilding and only reports success once CheckFTS independently
confirms it.

Fixes #289
